### PR TITLE
Fix script and improved clarity

### DIFF
--- a/babylon_mnemonic_to_keys.py
+++ b/babylon_mnemonic_to_keys.py
@@ -1,22 +1,19 @@
 from bip_utils import Bip39SeedGenerator, Bip32Slip10Ed25519
-#Ed25519
 from radix_engine_toolkit import *
 from getpass import getpass
 
 network_id = 0x01
 
-print ("Enter a mnemonic string:")
-pw = getpass()
+pw = getpass("Enter a mnemonic string: ")
 
 MNEMONIC = pw
 print('\n')
-
 
 # Seed phrase created in Babylon wallet
 seed_bytes = Bip39SeedGenerator(MNEMONIC).Generate()
 
 slip10_ctx = Bip32Slip10Ed25519.FromSeedAndPath(
-    seed_bytes, "m/44'/1022'/1'/525'/1460'/0'"
+    seed_bytes, "m/44'/1022'/1'/525'/1460'/1'"
 )
 
 # Get private and public keys as hex
@@ -25,13 +22,10 @@ public_key_hex = slip10_ctx.PublicKey().RawUncompressed().ToHex()
 
 # Convert to RET types
 private_key_bytes: bytes = int(private_key_hex, 16).to_bytes(32, "big")
-private_key: PrivateKey = PrivateKey.new_ed25519(list(private_key_bytes))
+private_key: PrivateKey = PrivateKey.new_ed25519(private_key_bytes)
 public_key: PublicKey = private_key.public_key()
 
-
-#print(public_key)
-#print(private_key)
-print("Private Key Bytes (you'll need this later :)): ",private_key_bytes)
+print("Private Key Bytes (you'll need this later :)): ", private_key_bytes)
 
 print('\n')
 account: Address = derive_virtual_account_address_from_public_key(


### PR DESCRIPTION
Script was failing, because it converted `private_key_bytes` into a list, which led to an error.

I also removed `print ("Enter a mnemonic string:")` and revised `pw = getpass()` to `pw = getpass("Enter a mnemonic string: ")` so that the script does not ask for a password, which I found confusing.

Finally, I revised the wallet derivation path to `m/44'/1022'/1'/525'/1460'/1'`, because this was where the first address generated with the seed was located in Radix Wallet.